### PR TITLE
fix dialyzer error after upgrade to erlang19

### DIFF
--- a/include/ej.hrl
+++ b/include/ej.hrl
@@ -69,7 +69,7 @@
 %% The return record for validity checks
 -record(ej_invalid, {
           type          :: ej_spec_type(),
-          key           :: binary(),
+          key           :: binary()             | undefined,
           found         :: json_term()          | undefined,
           found_type    :: ej_json_type_name()  | any_value | undefined,
           expected_type :: ej_json_type_name()  | any_value | undefined,


### PR DESCRIPTION
dialyzer no longer implicitly assumes that uninitialized record fields
are allowed to be set to the atom 'undefined'.  naturally this causes
breakages.  here, we are telling dialyzer that key is allowed to be
'undefined'.

Signed-off-by: Lincoln Baker <lbaker@chef.io>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
